### PR TITLE
Release v1.1.19

### DIFF
--- a/index.min.d.ts
+++ b/index.min.d.ts
@@ -570,6 +570,8 @@ interface clickElementEvent {
     placeholder?: string;
     /** The value attribute of button / input tag */
     value?: string;
+    /** The checked state ("true"/"false") of an <input type="checkbox"> at click time */
+    checked?: string;
     /** The custom attribute of clicked element */
     [key: string]: string | undefined | null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@convivainc/tracker-core",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Types file reference for Conviva ECO Tracker Core",
   "main": "index.min.d.ts",
   "types": "index.min.d.ts",


### PR DESCRIPTION
This PR prepares the **1.1.19** release of `@convivainc/tracker-core`.

### Changes

- `package.json` version bump `1.1.18 → 1.1.19`
- Refreshed `index.min.d.ts` types from current source build (built from `snowplow-javascript-horizontal-prod` master HEAD via `rush build --to @convivainc/tracker-core`)

No README / CHANGELOG / AGENTS.md changes this round — types-only package, content diff is a single new optional `checked` property on the `clickElementEvent` type.

### Related

Part of the DPI v2.2.0 / Replay v1.0.4 release train.